### PR TITLE
Add global variable to adjust the flash time

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This plugin provides a user-command called `PingCursor` which illuminates the
 current location of the cursor temporarily so that you can easily find it.
-Please see the *Configuration* section for details on how best to utilize the
+Please see the *Mappings* section for details on how best to utilize the
 `PingCursor` command.
 
 ## Installation
@@ -23,11 +23,11 @@ management. If you aren't using vim8 then upgrade to get the latest goodness.
 
 If you are using another method, you are on your own.
 
-## Configuration
+## Mappings
 
-The recommended configuration for this plugin is to simply map a key combo to
-run the `PingCursor` command for you. This can easily be done by adding the
-following to your `~/.vimrc`.
+The recommended mapping for this plugin is to simply map a key combo to run the
+`PingCursor` command for you. This can easily be done by adding the following
+to your `~/.vimrc`.
 
     nnoremap <leader>p :PingCursor<cr>
 
@@ -39,6 +39,13 @@ You can of course map this command anyway you like, or even choose not to map
 it and just execute the command as follows when you need it.
 
     :PingCursor<cr>
+
+## Configuration
+
+The duration of the cursor flash can be customized in your `~/.vimrc`:
+
+    " This is the default
+    let g:ping_cursor_flash_milliseconds = 250
 
 ## Why I Built This
 

--- a/doc/ping-cursor.txt
+++ b/doc/ping-cursor.txt
@@ -29,6 +29,13 @@ nnoremap <leader>p :PingCursor<cr>
 The above mapping would make it so that <leader>p when pressed would execute
 the :PingCursor command.
 
+CONFIGURATION                                   *ping-cursor-configuration*
+
+The duration of the cursor flash can be customized in your vimrc:
+
+ " This is the default
+ let g:ping_cursor_flash_milliseconds = 250
+
 ABOUT                                           *ping-cursor-about*
 
 Grab the latest version, report a bug, or contribute on GitHub:

--- a/plugin/vim-ping-cursor.vim
+++ b/plugin/vim-ping-cursor.vim
@@ -10,11 +10,18 @@
 " https://gist.github.com/pera/2624765
 " http://vim.1045645.n5.nabble.com/Vim-7-slows-down-when-highlighting-cursor-line-td1148280.html
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+if !exists('g:ping_cursor_flash_milliseconds')
+  let g:ping_cursor_flash_milliseconds = 250
+endif
+
 function! s:PingCursor()
   set cursorline cursorcolumn
   redraw
-  sleep 250m
+  execute 'sleep' g:ping_cursor_flash_milliseconds . 'm'
   set nocursorline nocursorcolumn
 endfunction
+
+
 
 command PingCursor :call s:PingCursor()


### PR DESCRIPTION
The default is still 250 milliseconds, but now it can be customized in the vimrc.